### PR TITLE
Updating the default pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
-## Ticket
-[TEAM-XYZ](https://xyz.atlassian.net/browse/TEAM-XYZ)
+<!---
+Please ensure that the PR Title starts with a reference to the Jira Issue 
+in the format: [TEAM-XYZ] pr title
+ -->
 
 ## Why?
 <!---
@@ -11,12 +13,37 @@ Please include relevant motivation and context.
 Give a brief explanation of the changes you did in this PR
 -->
 
-## How to test?
-<!---
-Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
--->
-
 ## Type of change?
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Breaking change (would cause existing functionality to not work as expected)
+- [ ] Requires a documentation update
+- [ ] Includes a database migration (Deploy Notes section should inform if migrations should run before or after deployment)
+
+## How to test?
+<!---
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+-->
+
+## Checklist
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have followed the standards related to my specific guild
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+
+## Security
+- [ ] Requires a security review  
+- [ ] Security review has been done
+
+## Deploy notes
+<!---
+Notes regarding deployment. These should note any db migrations, etc.
+-->
+
+## Screenshots (in case of UI change)
+<!---
+Add screenshots in case it's a UI change to facilitate review and testing.
+-->


### PR DESCRIPTION
## Why?
We want to standardise the format of all PR request across the company and ensure that sections like security are reflected.

## What?
@paulazavamed did analyse all currently used project specific templates and came up with the new default
The main change is the inclusion of a standard security section. we also removed the duplication of the ticket number on PR title and inside the ticket

## How to test?
n/a

## Type of change?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)