### PR TITLE
[ARCH-28] Add backstage definition file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,23 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+    github.com/project-slug: healthbridgeltd/.github
+    jenkins.io/job-full-name: ""
+    jira/component: ""
+    jira/project-key: ""
+    newrelic.com/dashboard-guid: ""
+    sonarqube.org/project-key: ""
+  description: Standard templates for github repos
+  links:
+  - title: Confluence Docs
+    url: https://zavamed.atlassian.net/wiki/spaces/TPF/pages/1305575425/
+  - title: C4 Component Diagram
+    url: https://zavamed.atlassian.net/wiki/spaces/ARCH/pages/2718041888/Ordoclic+Fulfilment+Service+Placeholder
+  name: .github
+  tags: []
+spec:
+  lifecycle: production
+  owner: architecture
+  type: service


### PR DESCRIPTION
## Please follow these instructions to complete the file
- [ ] Add Readable name: .github.yaml
- [ ] Change links to proper ones (Confluence Doc, C4 Diagram) metadata.links
- [ ] Add Jenkins Job
- [ ] Add Jira Project ( this matches the repo name )
- [ ] Add Jira Project Key (Disco, ...)
- [ ] Newrelic Dashboard ID
- [ ] SonarQube Project Name
- [ ] Change lifecycle to 'experimental' or 'deprecated' if applicable: spec.lifecycle
- [ ] Change type to 'website' or 'library' if applicable: spec.type

Full description format of Catalog entities can be found here [https://backstage.io/docs/features/software-catalog/descriptor-format](https://backstage.io/docs/features/software-catalog/descriptor-format)
Full explanation on how to format the catalog-info.yaml to make the girhub repo ready to be added to Backstage [https://zavamed.atlassian.net/wiki/spaces/ARCH/pages/3243376725/How+to+add+a+repository+to+Backstage](https://zavamed.atlassian.net/wiki/spaces/ARCH/pages/3243376725/How+to+add+a+repository+to+Backstage)
